### PR TITLE
Issue 29: Consistent number of arguments across OSes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file-rotate"
-version = "0.7.6"
+version = "0.8.0"
 authors = ["Kevin Robert Stravers <kevin@stravers.net>", "Erlend Langseth <3rlendhl@gmail.com>"]
 edition = "2018"
 description = "Log rotation for files"

--- a/examples/rotate_by_date.rs
+++ b/examples/rotate_by_date.rs
@@ -11,7 +11,6 @@ fn main() {
         AppendTimestamp::with_format("%Y-%m-%d", FileLimit::MaxFiles(7), DateFrom::DateYesterday),
         ContentLimit::Time(TimeFrequency::Daily),
         Compression::None,
-        #[cfg(unix)]
         None,
     );
 


### PR DESCRIPTION
- take `Option<OpenOptions>` in `FileRotate::new`

Closes #29 